### PR TITLE
Persistent User Account

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -42,14 +42,13 @@ use tauri_plugin_http::reqwest::{ self };
 
 #[tauri::command]
 pub async fn get_free_coins(tokens: State<'_, Tokens>) -> Result<(), Error> {
+  // Use default account
+  let auth_token = None;
   let permission_token = tokens.permission
     .lock()
     .map_err(|_| FailedToObtainPermissionTokenLock())?
     .clone();
-  let auth_token = tokens.auth
-    .lock()
-    .map_err(|_| FailedToObtainAuthTokenLock())?
-    .clone();
+
   let handle = tauri::async_runtime::spawn(async move { free_coins(auth_token, permission_token).await.unwrap() });
   handle.await.unwrap();
   Ok(())
@@ -57,14 +56,13 @@ pub async fn get_free_coins(tokens: State<'_, Tokens>) -> Result<(), Error> {
 
 #[tauri::command]
 pub async fn get_balances(tokens: State<'_, Tokens>) -> Result<AccountsGetBalancesResponse, Error> {
+  // Use default account
+  let auth_token = None;
   let permission_token = tokens.permission
     .lock()
     .map_err(|_| FailedToObtainPermissionTokenLock())?
     .clone();
-  let auth_token = tokens.auth
-    .lock()
-    .map_err(|_| FailedToObtainAuthTokenLock())?
-    .clone();
+
   let handle = tauri::async_runtime::spawn(async move { balances(auth_token, permission_token).await });
   let balances = handle.await??;
 

--- a/src-tauri/src/rpc.rs
+++ b/src-tauri/src/rpc.rs
@@ -39,9 +39,9 @@ pub async fn permission_token() -> Result<(String, String), anyhow::Error> {
   Ok((acc_res.permissions_token, auth_token))
 }
 
-pub async fn free_coins(auth_token: String, permissions_token: String) -> Result<(), anyhow::Error> {
+pub async fn free_coins(auth_token: Option<String>, permissions_token: String) -> Result<(), anyhow::Error> {
   let free_coins_params = AccountsCreateFreeTestCoinsRequest {
-    account: Some(ComponentAddressOrName::Name(auth_token)),
+    account: auth_token.map(|token| ComponentAddressOrName::Name(token)),
     amount: (100_000_000).into(),
     max_fee: None,
     key_id: None,
@@ -51,9 +51,9 @@ pub async fn free_coins(auth_token: String, permissions_token: String) -> Result
   Ok(())
 }
 
-pub async fn balances(auth_token: String, permissions_token: String) -> Result<AccountsGetBalancesResponse, Error> {
+pub async fn balances(auth_token: Option<String>, permissions_token: String) -> Result<AccountsGetBalancesResponse, Error> {
   let balance_req = AccountsGetBalancesRequest {
-    account: Some(ComponentAddressOrName::Name(auth_token)),
+    account: auth_token.map(|token| ComponentAddressOrName::Name(token)),
     refresh: false,
   };
   let method = "accounts.get_balances".to_string();


### PR DESCRIPTION
`get_account_or_default` in tari_dan_wallet_daemon  returns default account if auth_token not provided. We shouldn't pass any auth_token unless we want to generate another account.