### PR TITLE
fix(ui): error message for dev tapplet invalid manifest

### DIFF
--- a/src/components/DevTapplet.tsx
+++ b/src/components/DevTapplet.tsx
@@ -22,7 +22,7 @@ export function ActiveDevTapplet() {
         } else {
           dispatch(
             errorActions.showError({
-              message: `manifest-package-name-mismatch | packageName: ${state?.package_name} & manifestId: ${manifest?.id} & endpoint: ${state?.endpoint}`,
+              message: `manifest-package-name-mismatch | packageName-${state?.package_name} & manifestId-${manifest?.id} & endpoint-${state?.endpoint}`,
               errorSource: ErrorSource.FRONTEND,
             })
           )
@@ -30,7 +30,7 @@ export function ActiveDevTapplet() {
       } catch (error) {
         dispatch(
           errorActions.showError({
-            message: `fetching-taplet-manifest-failed | error: ${error}`,
+            message: `fetching-tapplet-manifest-failed | error-${error}`,
             errorSource: ErrorSource.FRONTEND,
           })
         )


### PR DESCRIPTION
Description
---
Fix error message for dev tapplet when invalid tapplet manifest is detected

Motivation and Context
---
Hosting invalid dev tapplet caused app to crash

How Has This Been Tested?
---
Tested manually. I have registered tariswap tapplet as dev tapplet but later hosted faucet tapplet.

What process can a PR reviewer use to test or verify this change?
---
Register one dev tapplet but host another after.

Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify
