### PR TITLE
fix(tapplets): use same manifest file for dev tapplets as for registered tapplets

### DIFF
--- a/locales/en/errors.json
+++ b/locales/en/errors.json
@@ -1,5 +1,5 @@
 {
-  "manifest-package-name-mismatch": "Tapplet manifest does not match package name. Expected: {{ packageName }} Received: {{ manifestId }} from: {{ endpoint }}/tapplet.manifest.json",
+  "manifest-package-name-mismatch": "Tapplet manifest does not match package name. Expected: {{ expectedPackageName }} Received: {{ receivedPackageName }} from: {{- endpoint }}/tapplet.manifest.json",
   "fetching-taplet-manifest-failed": "Error fetching tapplet manifest: {{ error }}",
   "no-pending-transaction-found": "No pending transaction found",
   "no-data-in-event": "No data in event",

--- a/locales/pl/errors.json
+++ b/locales/pl/errors.json
@@ -1,5 +1,5 @@
 {
-  "manifest-package-name-mismatch": "Manifest tapplet'u nie pasuje do nazwy pakietu. Oczekiwano: {{ packageName }} Otrzymano: {{ manifestId }} z: {{ endpoint }}/tapplet.manifest.json",
+  "manifest-package-name-mismatch": "Manifest tapplet'u nie pasuje do nazwy pakietu. Oczekiwano: {{ expectedPackageName }} Otrzymano: {{ receivedPackageName }} z: {{- endpoint }}/tapplet.manifest.json",
   "fetching-taplet-manifest-failed": "Błąd pobierania manifestu tapplet'u: {{ error }}",
   "no-pending-transaction-found": "Nie znaleziono oczekującej transakcji",
   "no-data-in-event": "Brak danych w zdarzeniu",

--- a/src-tauri/migrations/2024-04-25-073069_create_tapplets/up.sql
+++ b/src-tauri/migrations/2024-04-25-073069_create_tapplets/up.sql
@@ -48,7 +48,6 @@ CREATE TABLE dev_tapplet (
   id INTEGER PRIMARY KEY,
   package_name TEXT NOT NULL,
   endpoint TEXT NOT NULL,
-  tapplet_name TEXT NOT NULL,
   display_name TEXT NOT NULL,
   UNIQUE(endpoint)
 );

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -366,8 +366,7 @@ pub async fn add_dev_tapplet(
   let mut store = SqliteStore::new(db_connection.0.clone());
   let new_dev_tapplet = CreateDevTapplet {
     endpoint: &endpoint,
-    package_name: &manifest_res.id,
-    tapplet_name: &manifest_res.name,
+    package_name: &manifest_res.package_name,
     display_name: &manifest_res.display_name,
   };
 

--- a/src-tauri/src/database/models.rs
+++ b/src-tauri/src/database/models.rs
@@ -163,7 +163,6 @@ pub struct DevTapplet {
   pub id: Option<i32>,
   pub package_name: String,
   pub endpoint: String,
-  pub tapplet_name: String,
   pub display_name: String,
 }
 
@@ -172,7 +171,6 @@ pub struct DevTapplet {
 pub struct CreateDevTapplet<'a> {
   pub endpoint: &'a str,
   pub package_name: &'a str,
-  pub tapplet_name: &'a str,
   pub display_name: &'a str,
 }
 
@@ -181,7 +179,6 @@ impl<'a> From<&CreateDevTapplet<'a>> for UpdateDevTapplet {
     UpdateDevTapplet {
       endpoint: create_dev_tapplet.endpoint.to_string(),
       package_name: create_dev_tapplet.package_name.to_string(),
-      tapplet_name: create_dev_tapplet.tapplet_name.to_string(),
       display_name: create_dev_tapplet.display_name.to_string(),
     }
   }
@@ -192,7 +189,6 @@ impl<'a> From<&CreateDevTapplet<'a>> for UpdateDevTapplet {
 pub struct UpdateDevTapplet {
   pub endpoint: String,
   pub package_name: String,
-  pub tapplet_name: String,
   pub display_name: String,
 }
 

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -5,7 +5,6 @@ diesel::table! {
         id -> Nullable<Integer>,
         package_name -> Text,
         endpoint -> Text,
-        tapplet_name -> Text,
         display_name -> Text,
     }
 }
@@ -57,4 +56,11 @@ diesel::joinable!(installed_tapplet -> tapplet (tapplet_id));
 diesel::joinable!(installed_tapplet -> tapplet_version (tapplet_version_id));
 diesel::joinable!(tapplet_audit -> tapplet (tapplet_id));
 diesel::joinable!(tapplet_version -> tapplet (tapplet_id));
-diesel::allow_tables_to_appear_in_same_query!(dev_tapplet, installed_tapplet, tapplet, tapplet_audit, tapplet_version);
+
+diesel::allow_tables_to_appear_in_same_query!(
+    dev_tapplet,
+    installed_tapplet,
+    tapplet,
+    tapplet_audit,
+    tapplet_version,
+);

--- a/src-tauri/src/interface/dev_tapplet.rs
+++ b/src-tauri/src/interface/dev_tapplet.rs
@@ -1,7 +1,7 @@
 #[derive(Debug, serde::Deserialize)]
 pub struct DevTappletResponse {
-  pub name: String,
-  pub id: String,
+  #[serde(rename = "packageName")]
+  pub package_name: String,
   #[serde(rename = "displayName")]
   pub display_name: String,
 }

--- a/src/components/DevTapplet.tsx
+++ b/src/components/DevTapplet.tsx
@@ -17,12 +17,12 @@ export function ActiveDevTapplet() {
       try {
         const response = await fetch(`${state?.endpoint}/tapplet.manifest.json`)
         const manifest = await response.json()
-        if (manifest?.id === state?.package_name) {
+        if (manifest?.packageName === state?.package_name) {
           setIsVerified(true)
         } else {
           dispatch(
             errorActions.showError({
-              message: `manifest-package-name-mismatch | packageName-${state?.package_name} & manifestId-${manifest?.id} & endpoint-${state?.endpoint}`,
+              message: `manifest-package-name-mismatch | expectedPackageName-${state?.package_name} & receivedPackageName-${manifest?.packageName} & endpoint-${state?.endpoint}`,
               errorSource: ErrorSource.FRONTEND,
             })
           )

--- a/src/types/tapplet.ts
+++ b/src/types/tapplet.ts
@@ -28,7 +28,6 @@ export interface DevTapplet {
   id: string
   package_name: string
   endpoint: string
-  tapplet_name: string
   display_name: string
   about_summary: string
   about_description: string


### PR DESCRIPTION
Description
---
Feature to use dev tapplets came before registry and the were using ad hoc tapplet manifest which was different from the registered tapplets.
This PR get rid of older tapplet manifest used only by dev tapplets and utilizes the standard format created by [tapp-registrant](https://github.com/karczuRF/tapp-registrant).

Motivation and Context
---
Standardize tapplet manifest format and simplify development.

How Has This Been Tested?
---
Tested manually.

What process can a PR reviewer use to test or verify this change?
---
Use either [tapplet-faucet](https://github.com/MCozhusheck/faucet-tapplet) or [tariswap](https://github.com/MCozhusheck/tariswap-tapplet) and add those as dev tapplets.


Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [x] Other - Please specify

Run migrations for ```/.local/share/universe.tari/tari_universe.sqlite3``` db with command: `diesel migration redo` if db already exists
