### PR TITLE
fix(provider): list substates

### DIFF
--- a/src/provider/TariUniverseProvider.ts
+++ b/src/provider/TariUniverseProvider.ts
@@ -192,8 +192,8 @@ export class WalletDaemonTariProvider implements TariProvider {
     const res = await this.client.substatesList({
       filter_by_template,
       filter_by_type,
-      limit: BigInt(limit ?? 0),
-      offset: BigInt(offset ?? 0),
+      limit: limit ? BigInt(limit) : null,
+      offset: offset ? BigInt(offset) : null,
     })
     const substates = res.substates.map((s) => ({
       substate_id: substateIdToString(s.substate_id),


### PR DESCRIPTION
Description
---
Fix `listSubstates` args. Should use bigint from number or null.

Motivation and Context
---
Error occurs if TU Provider calls `listSubstate` function with null for `limit` or `offset`

How Has This Been Tested?
---
Manually tested with TU templates.

What process can a PR reviewer use to test or verify this change?
---
Pull this branch, build and use locally with any template which uses `lisSubstates`

<!-- Checklist -->
<!-- 1. Is the title of your PR in the form that would make nice release notes? The title, excluding the conventional commit
tag, will be included exactly as is in the CHANGELOG, so please think about it carefully. -->


Breaking Changes
---

- [x] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [ ] Other - Please specify

<!-- Does this include a breaking change? If so, include this line as a footer -->
<!-- BREAKING CHANGE: Description what the user should do, e.g. delete a database, resync the chain -->
