### PR TITLE
feat(tapplets): predownload tapplets icons

### DIFF
--- a/src-tauri/migrations/2024-04-25-073069_create_tapplets/down.sql
+++ b/src-tauri/migrations/2024-04-25-073069_create_tapplets/down.sql
@@ -4,3 +4,4 @@ DROP TABLE tapplet_version;
 DROP TABLE tapplet_audit;
 DROP TABLE installed_tapplet;
 DROP TABLE dev_tapplet;
+DROP TABLE tapplet_asset;

--- a/src-tauri/migrations/2024-04-25-073069_create_tapplets/up.sql
+++ b/src-tauri/migrations/2024-04-25-073069_create_tapplets/up.sql
@@ -51,3 +51,11 @@ CREATE TABLE dev_tapplet (
   display_name TEXT NOT NULL,
   UNIQUE(endpoint)
 );
+
+CREATE TABLE tapplet_asset (
+  id INTEGER PRIMARY KEY,
+  tapplet_id INTEGER,
+  icon_url TEXT NOT NULL,
+  background_url TEXT NOT NULL,
+  FOREIGN KEY (tapplet_id) REFERENCES tapplet(id)
+);

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -15,7 +15,6 @@ use crate::{
       DevTapplet,
       InstalledTapplet,
       Tapplet,
-      TappletAsset,
       UpdateInstalledTapplet,
       UpdateTapplet,
     },
@@ -38,6 +37,7 @@ use crate::{
     get_tapp_download_path,
   },
   tapplet_server::start,
+  AssetServer,
   DatabaseConnection,
   ShutdownTokens,
   Tokens,
@@ -136,6 +136,11 @@ pub async fn close_tapplet(installed_tapplet_id: i32, shutdown_tokens: State<'_,
   }
 
   Ok(())
+}
+
+#[tauri::command]
+pub fn get_assets_server_addr(state: tauri::State<'_, AssetServer>) -> Result<String, String> {
+  Ok(format!("http://{}", state.addr))
 }
 
 #[tauri::command]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -1,18 +1,21 @@
 use tari_wallet_daemon_client::types::AccountsGetBalancesResponse;
-use tauri::{ self, State };
+use tauri::{ self, AppHandle, State };
 use std::path::PathBuf;
 
 use crate::{
+  constants::REGISTRY_URL,
   database::{
     models::{
       CreateDevTapplet,
       CreateInstalledTapplet,
       CreateTapplet,
+      CreateTappletAsset,
       CreateTappletAudit,
       CreateTappletVersion,
       DevTapplet,
       InstalledTapplet,
       Tapplet,
+      TappletAsset,
       UpdateInstalledTapplet,
       UpdateTapplet,
     },
@@ -26,7 +29,14 @@ use crate::{
   hash_calculator::calculate_checksum,
   interface::{ DevTappletResponse, InstalledTappletWithName, RegisteredTappletWithVersion, RegisteredTapplets },
   rpc::{ balances, free_coins, make_request },
-  tapplet_installer::{ check_extracted_files, delete_tapplet, download_file, extract_tar, get_tapp_download_path },
+  tapplet_installer::{
+    check_extracted_files,
+    delete_tapplet,
+    download_asset,
+    download_file_and_archive,
+    extract_tar,
+    get_tapp_download_path,
+  },
   tapplet_server::start,
   DatabaseConnection,
   ShutdownTokens,
@@ -143,7 +153,7 @@ pub async fn download_and_extract_tapp(
   // download tarball
   let url = tapp_version.registry_url.clone();
   let download_path = tapplet_path.clone();
-  let handle = tauri::async_runtime::spawn(async move { download_file(&url, download_path).await });
+  let handle = tauri::async_runtime::spawn(async move { download_file_and_archive(&url, download_path).await });
   handle.await?.map_err(|_| Error::RequestError(FailedToDownload { url: tapp_version.registry_url }))?;
 
   //extract tarball
@@ -196,10 +206,8 @@ pub fn read_tapp_registry_db(db_connection: State<'_, DatabaseConnection>) -> Re
  *  REGISTERED TAPPLETS - FETCH DATA FROM MANIFEST JSON
  */
 #[tauri::command]
-pub async fn fetch_tapplets(db_connection: State<'_, DatabaseConnection>) -> Result<(), Error> {
-  let manifest_endpoint = String::from(
-    "https://raw.githubusercontent.com/karczuRF/tapp-registry/main/dist/tapplets-registry.manifest.json"
-  );
+pub async fn fetch_tapplets(app_handle: AppHandle, db_connection: State<'_, DatabaseConnection>) -> Result<(), Error> {
+  let manifest_endpoint = format!("{}/dist/tapplets-registry.manifest.json", REGISTRY_URL);
   let manifest_res = reqwest
     ::get(&manifest_endpoint).await
     .map_err(|_| RequestError(FetchManifestError { endpoint: manifest_endpoint.clone() }))?
@@ -212,12 +220,11 @@ pub async fn fetch_tapplets(db_connection: State<'_, DatabaseConnection>) -> Res
 
   for tapplet_manifest in tapplets.registered_tapplets.values() {
     let inserted_tapplet = store.create(&CreateTapplet::from(tapplet_manifest))?;
-    let tapplet_db_id = inserted_tapplet.id;
 
     // for audit_data in tapplet_manifest.metadata.audits.iter() {
     //   store.create(
     //     &(CreateTappletAudit {
-    //       tapplet_id: tapplet_db_id,
+    //       tapplet_id: inserted_tapplet.id,
     //       auditor: &audit_data.auditor,
     //       report_url: &audit_data.report_url,
     //     })
@@ -227,12 +234,26 @@ pub async fn fetch_tapplets(db_connection: State<'_, DatabaseConnection>) -> Res
     for (version, version_data) in tapplet_manifest.versions.iter() {
       store.create(
         &(CreateTappletVersion {
-          tapplet_id: tapplet_db_id,
+          tapplet_id: inserted_tapplet.id,
           version: &version,
           integrity: &version_data.integrity,
           registry_url: &version_data.registry_url,
         })
       )?;
+    }
+
+    match store.get_tapplet_assets_by_tapplet_id(inserted_tapplet.id.unwrap())? {
+      Some(_) => {}
+      None => {
+        let tapplet_assets = download_asset(app_handle.clone(), inserted_tapplet.registry_id).await?;
+        store.create(
+          &(CreateTappletAsset {
+            tapplet_id: inserted_tapplet.id,
+            icon_url: &tapplet_assets.icon_url,
+            background_url: &tapplet_assets.background_url,
+          })
+        )?;
+      }
     }
   }
   Ok(())

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -1,3 +1,4 @@
 pub const TAPPLETS_INSTALLED_DIR: &'static str = "tapplets_installed";
+pub const TAPPLETS_ASSETS_DIR: &'static str = "assets";
 pub const DB_FILE_NAME: &'static str = "tari_universe.sqlite3";
 pub const REGISTRY_URL: &'static str = "https://raw.githubusercontent.com/karczuRF/tapp-registry/main";

--- a/src-tauri/src/constants.rs
+++ b/src-tauri/src/constants.rs
@@ -1,2 +1,3 @@
 pub const TAPPLETS_INSTALLED_DIR: &'static str = "tapplets_installed";
 pub const DB_FILE_NAME: &'static str = "tari_universe.sqlite3";
+pub const REGISTRY_URL: &'static str = "https://raw.githubusercontent.com/karczuRF/tapp-registry/main";

--- a/src-tauri/src/database/models.rs
+++ b/src-tauri/src/database/models.rs
@@ -227,3 +227,39 @@ pub struct UpdateTappletAudit {
   pub auditor: String,
   pub report_url: String,
 }
+
+#[derive(Queryable, Selectable, Debug, Serialize)]
+#[diesel(table_name = tapplet_asset)]
+#[diesel(check_for_backend(diesel::sqlite::Sqlite))]
+pub struct TappletAsset {
+  pub id: Option<i32>,
+  pub tapplet_id: Option<i32>,
+  pub icon_url: String,
+  pub background_url: String,
+}
+
+#[derive(Insertable, Debug)]
+#[diesel(table_name = tapplet_asset)]
+pub struct CreateTappletAsset<'a> {
+  pub tapplet_id: Option<i32>,
+  pub icon_url: &'a str,
+  pub background_url: &'a str,
+}
+
+impl<'a> From<&CreateTappletAsset<'a>> for UpdateTappletAsset {
+  fn from(create_tapplet_asset: &CreateTappletAsset) -> Self {
+    UpdateTappletAsset {
+      tapplet_id: create_tapplet_asset.tapplet_id,
+      icon_url: create_tapplet_asset.icon_url.to_string(),
+      background_url: create_tapplet_asset.background_url.to_string(),
+    }
+  }
+}
+
+#[derive(Debug, AsChangeset)]
+#[diesel(table_name = tapplet_asset)]
+pub struct UpdateTappletAsset {
+  pub tapplet_id: Option<i32>,
+  pub icon_url: String,
+  pub background_url: String,
+}

--- a/src-tauri/src/database/schema.rs
+++ b/src-tauri/src/database/schema.rs
@@ -34,6 +34,15 @@ diesel::table! {
 }
 
 diesel::table! {
+    tapplet_asset (id) {
+        id -> Nullable<Integer>,
+        tapplet_id -> Nullable<Integer>,
+        icon_url -> Text,
+        background_url -> Text,
+    }
+}
+
+diesel::table! {
     tapplet_audit (id) {
         id -> Nullable<Integer>,
         tapplet_id -> Nullable<Integer>,
@@ -54,6 +63,7 @@ diesel::table! {
 
 diesel::joinable!(installed_tapplet -> tapplet (tapplet_id));
 diesel::joinable!(installed_tapplet -> tapplet_version (tapplet_version_id));
+diesel::joinable!(tapplet_asset -> tapplet (tapplet_id));
 diesel::joinable!(tapplet_audit -> tapplet (tapplet_id));
 diesel::joinable!(tapplet_version -> tapplet (tapplet_id));
 
@@ -61,6 +71,7 @@ diesel::allow_tables_to_appear_in_same_query!(
     dev_tapplet,
     installed_tapplet,
     tapplet,
+    tapplet_asset,
     tapplet_audit,
     tapplet_version,
 );

--- a/src-tauri/src/interface/tapplet.rs
+++ b/src-tauri/src/interface/tapplet.rs
@@ -28,3 +28,9 @@ pub struct RegisteredTappletWithVersion {
   pub registered_tapp: Tapplet,
   pub tapp_version: TappletVersion,
 }
+
+#[derive(Serialize)]
+pub struct TappletAssets {
+  pub icon_url: String,
+  pub background_url: String,
+}

--- a/src-tauri/src/tapplet_installer.rs
+++ b/src-tauri/src/tapplet_installer.rs
@@ -4,7 +4,7 @@ use std::{ fs, io::Write, path::PathBuf };
 use flate2::read::GzDecoder;
 use tar::Archive;
 use crate::{
-  constants::REGISTRY_URL,
+  constants::{ REGISTRY_URL, TAPPLETS_ASSETS_DIR },
   error::{ Error::{ self, IOError, RequestError }, IOError::*, RequestError::* },
   interface::TappletAssets,
 };
@@ -142,7 +142,7 @@ async fn download_file(url: &str, dest: PathBuf) -> Result<(), Error> {
 }
 
 fn get_or_create_tapp_asset_dir(tapp_root_dir: PathBuf, tapplet_name: &str) -> Result<PathBuf, Error> {
-  let tapp_asset_dir = tapp_root_dir.join("assets").join(tapplet_name);
+  let tapp_asset_dir = tapp_root_dir.join(TAPPLETS_ASSETS_DIR).join(tapplet_name);
   let path = tapp_asset_dir
     .clone()
     .into_os_string()

--- a/src/components/TappletsInstalled.tsx
+++ b/src/components/TappletsInstalled.tsx
@@ -5,16 +5,16 @@ import tariLogo from "../assets/tari.svg"
 import { NavLink } from "react-router-dom"
 import { TabKey } from "../views/Tabs"
 import { useDispatch, useSelector } from "react-redux"
-import { installedTappletsSelectors } from "../store/installedTapplets/installedTapplets.selector"
 import { devTappletsSelectors } from "../store/devTapplets/devTapplets.selector"
 import { installedTappletsActions } from "../store/installedTapplets/installedTapplets.slice"
 import { devTappletsActions } from "../store/devTapplets/devTapplets.slice"
 import { DevTapplet, InstalledTappletWithName } from "@type/tapplet"
 import { useTranslation } from "react-i18next"
+import { installedTappletsListSelector } from "../store/installedTapplets/installedTapplets.selector"
 
 export const TappletsInstalled: React.FC = () => {
   const { t } = useTranslation("components")
-  const installedTapplets = useSelector(installedTappletsSelectors.selectAll)
+  const installedTapplets = useSelector(installedTappletsListSelector)
   const devTapplets = useSelector(devTappletsSelectors.selectAll)
   const dispatch = useDispatch()
 
@@ -39,7 +39,7 @@ export const TappletsInstalled: React.FC = () => {
         {installedTapplets.map((item, index) => (
           <ListItem key={index}>
             <ListItemAvatar>
-              <Avatar src={tariLogo} />
+              <Avatar src={item.logoAddr} />
             </ListItemAvatar>
             <ListItemText primary={item.display_name} />
             <IconButton aria-label="launch" style={{ marginRight: 10 }}>

--- a/src/components/TappletsRegistered.tsx
+++ b/src/components/TappletsRegistered.tsx
@@ -10,7 +10,6 @@ import {
   Typography,
 } from "@mui/material"
 import { InstallDesktop } from "@mui/icons-material"
-import tariLogo from "../assets/tari.svg"
 import AddDevTappletDialog from "./AddDevTappletDialog"
 import { useDispatch, useSelector } from "react-redux"
 import { registeredTappletsSelectors } from "../store/registeredTapplets/registeredTapplets.selector"
@@ -42,7 +41,7 @@ export const TappletsRegistered: React.FC = () => {
           {registeredTapplets.map((item) => (
             <ListItem key={item.package_name} sx={{ paddingTop: 2 }}>
               <ListItemAvatar>
-                <Avatar src={tariLogo} />
+                <Avatar src={item.logoAddr} />
               </ListItemAvatar>
               <ListItemText primary={item.package_name} />
               <IconButton aria-label="install" onClick={() => handleInstall(item.id)} sx={{ marginLeft: 8 }}>

--- a/src/store/installedTapplets/installedTapplets.selector.ts
+++ b/src/store/installedTapplets/installedTapplets.selector.ts
@@ -1,16 +1,27 @@
 import { createSelector } from "@reduxjs/toolkit"
 import { RootState } from "../store"
 import { installedTappletAdapter } from "./installedTapplets.slice"
+import { registeredTappletsSelectors } from "../registeredTapplets/registeredTapplets.selector"
 
 const installedTappletsStateSelector = (state: RootState) => state.installedTapplets
 export const installedTappletsSelectors = installedTappletAdapter.getSelectors<RootState>(
   (state) => state.installedTapplets.installedTapplets
 )
 
-const getAllInstalledTapplets = createSelector([installedTappletsStateSelector], (state) => state.installedTapplets)
+export const installedTappletsListSelector = createSelector(
+  [installedTappletsSelectors.selectAll, registeredTappletsSelectors.selectAll],
+  (installedTapplets, registeredTapplets) => {
+    return installedTapplets.map((installedTapplet) => {
+      const registeredTapplet = registeredTapplets.find(
+        (tapplet) => tapplet.id === installedTapplet.installed_tapplet.tapplet_id
+      )
+      return { ...installedTapplet, ...registeredTapplet }
+    })
+  }
+)
+
 const isInitialized = createSelector([installedTappletsStateSelector], (state) => state.isInitialized)
 
 export const installedTappletsSelector = {
-  getAllInstalledTapplets,
   isInitialized,
 }

--- a/src/store/registeredTapplets/registeredTapplets.action.ts
+++ b/src/store/registeredTapplets/registeredTapplets.action.ts
@@ -12,7 +12,13 @@ export const initializeAction = () => ({
     try {
       await invoke("fetch_tapplets")
       const registeredTapplets = await invoke("read_tapp_registry_db")
-      listenerApi.dispatch(registeredTappletsActions.initializeSuccess({ registeredTapplets }))
+      const assetsServerAddr = await invoke("get_assets_server_addr")
+      const tappletsWithAssets = registeredTapplets.map((tapp) => ({
+        ...tapp,
+        logoAddr: `${assetsServerAddr}/${tapp.package_name}/logo.svg`,
+        backgroundAddr: `${assetsServerAddr}/${tapp.package_name}/background.svg`,
+      }))
+      listenerApi.dispatch(registeredTappletsActions.initializeSuccess({ registeredTapplets: tappletsWithAssets }))
     } catch (error) {
       listenerApi.dispatch(registeredTappletsActions.initializeFailure({ errorMsg: error as string }))
     }

--- a/src/store/registeredTapplets/registeredTapplets.slice.ts
+++ b/src/store/registeredTapplets/registeredTapplets.slice.ts
@@ -1,5 +1,5 @@
 import { PayloadAction, createEntityAdapter, createSlice } from "@reduxjs/toolkit"
-import { RegisteredTapplet } from "@type/tapplet"
+import { RegisteredTappletWithAssets } from "@type/tapplet"
 import { listenerMiddleware } from "../store.listener"
 import { initializeAction } from "./registeredTapplets.action"
 import {
@@ -8,7 +8,7 @@ import {
   InitRegisteredTappletsFailurePayload,
 } from "./registeredTapplets.types"
 
-export const registeredTappletAdapter = createEntityAdapter<RegisteredTapplet>()
+export const registeredTappletAdapter = createEntityAdapter<RegisteredTappletWithAssets>()
 
 const registeredTappletsSlice = createSlice({
   name: "registeredTapplets",

--- a/src/store/registeredTapplets/registeredTapplets.types.ts
+++ b/src/store/registeredTapplets/registeredTapplets.types.ts
@@ -1,4 +1,4 @@
-import { RegisteredTapplet } from "../../types/tapplet"
+import { RegisteredTapplet, RegisteredTappletWithAssets } from "../../types/tapplet"
 import { EntityState } from "@reduxjs/toolkit"
 
 export type TappletStoreState = {
@@ -9,7 +9,7 @@ export type TappletStoreState = {
 
 export type InitRegisteredTappletsReqPayload = {}
 export type InitRegisteredTappletsSuccessPayload = {
-  registeredTapplets: RegisteredTapplet[]
+  registeredTapplets: RegisteredTappletWithAssets[]
 }
 export type InitRegisteredTappletsFailurePayload = {
   errorMsg: string

--- a/src/types/invoke.ts
+++ b/src/types/invoke.ts
@@ -11,4 +11,5 @@ declare module "@tauri-apps/api/core" {
     payload: { tappletId: string; installedTappletId: string }
   ): Promise<InstalledTappletWithName[]>
   function invoke(param: "get_balances", payload: {}): Promise<WalletBalances> // TODO use AccountsGetBalancesResponse from typescript-bindings packages after it's fixed
+  function invoke(param: "get_assets_server_addr"): Promise<string>
 }

--- a/src/types/tapplet.ts
+++ b/src/types/tapplet.ts
@@ -11,6 +11,11 @@ export type RegisteredTapplet = {
   category: string
 }
 
+export type RegisteredTappletWithAssets = RegisteredTapplet & {
+  logoAddr: string
+  backgroundAddr: string
+}
+
 export type InstalledTapplet = {
   id: string
   tapplet_id: string


### PR DESCRIPTION
Description
---
Pre-download and display tapplets icons. Registry holds icon for each tapplet but tari universe displayed fixed icon in every case.

Motivation and Context
---
Implement basic feature

How Has This Been Tested?
---
Tested manually

What process can a PR reviewer use to test or verify this change?
---
Just run application and check if there are icons next to the name for registered and installed tapplets.


Breaking Changes
---

- [ ] None
- [ ] Requires data directory on base node to be deleted
- [ ] Requires hard fork
- [x] Other - Please specify

Delete database and run tari universe to initialize it with new table
